### PR TITLE
Support for Webpack bundle (#33)

### DIFF
--- a/src/main/kotlin/com/compiler/server/compiler/components/KotlinToJSTranslator.kt
+++ b/src/main/kotlin/com/compiler/server/compiler/components/KotlinToJSTranslator.kt
@@ -1,32 +1,59 @@
 package com.compiler.server.compiler.components
 
+import com.compiler.server.model.BundleType
 import com.compiler.server.model.ErrorDescriptor
+import com.compiler.server.model.ExceptionDescriptor
 import com.compiler.server.model.TranslationJSResult
+import com.compiler.server.model.bean.LibrariesFile
 import com.compiler.server.model.toExceptionDescriptor
+import org.jetbrains.kotlin.js.config.JSConfigurationKeys
 import org.jetbrains.kotlin.js.config.JsConfig
 import org.jetbrains.kotlin.js.facade.K2JSTranslator
 import org.jetbrains.kotlin.js.facade.MainCallParameters
 import org.jetbrains.kotlin.js.facade.TranslationResult
 import org.jetbrains.kotlin.js.facade.exceptions.TranslationException
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.serialization.js.ModuleKind
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.Resource
 import org.springframework.stereotype.Service
+import org.springframework.util.FileCopyUtils
+import java.io.File
+import java.io.IOException
+import java.io.InputStreamReader
+import java.nio.file.Files
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 @Service
 class KotlinToJSTranslator(
   private val kotlinEnvironment: KotlinEnvironment,
-  private val errorAnalyzer: ErrorAnalyzer
+  private val errorAnalyzer: ErrorAnalyzer,
+  private val librariesFile: LibrariesFile
 ) {
+
+  @Value("classpath:package.json")
+  lateinit var packageJson: Resource
+
+  @Value("classpath:webpack.config.plain.js")
+  lateinit var webpackConfigPlain: Resource
+  @Value("classpath:webpack.config.minimized.js")
+  lateinit var webpackConfigMinimized: Resource
 
   private val JS_CODE_FLUSH = "kotlin.kotlin.io.output.flush();\n"
   private val JS_CODE_BUFFER = "\nkotlin.kotlin.io.output.buffer;\n"
 
-  fun translate(files: List<KtFile>, arguments: List<String>): TranslationJSResult {
+  fun translate(files: List<KtFile>, arguments: List<String>, bundleType: BundleType): TranslationJSResult {
     val errors = errorAnalyzer.errorsFrom(files, isJs = true)
     return try {
       if (errorAnalyzer.isOnlyWarnings(errors)) {
-        doTranslate(files, arguments).also {
+        val result = doTranslate(files, arguments, bundleType).also {
           it.addWarnings(errors)
+        }
+        if (bundleType == BundleType.NONE) {
+          result
+        } else {
+          webpackBundle(result, bundleType)
         }
       }
       else {
@@ -41,10 +68,18 @@ class KotlinToJSTranslator(
   @Throws(TranslationException::class)
   private fun doTranslate(
     files: List<KtFile>,
-    arguments: List<String>
+    arguments: List<String>,
+    bundleType: BundleType
   ): TranslationJSResult {
     val currentProject = kotlinEnvironment.coreEnvironment.project
-    val configuration = JsConfig(currentProject, kotlinEnvironment.jsEnvironment)
+    val jsEnvironment = if (bundleType == BundleType.NONE) {
+      kotlinEnvironment.jsEnvironment
+    } else {
+      kotlinEnvironment.jsEnvironment.copy().apply {
+        put(JSConfigurationKeys.MODULE_KIND, ModuleKind.UMD)
+      }
+    }
+    val configuration = JsConfig(currentProject, jsEnvironment)
     val reporter = object : JsConfig.Reporter() {
       override fun error(message: String) {}
       override fun warning(message: String) {}
@@ -56,7 +91,11 @@ class KotlinToJSTranslator(
       mainCallParameters = MainCallParameters.mainWithArguments(arguments)
     )
     return if (result is TranslationResult.Success) {
-      TranslationJSResult(JS_CODE_FLUSH + result.getCode() + JS_CODE_BUFFER)
+      if (bundleType == BundleType.NONE) {
+        TranslationJSResult(JS_CODE_FLUSH + result.getCode() + JS_CODE_BUFFER)
+      } else {
+        TranslationJSResult(result.getCode())
+      }
     }
     else {
       val errors = HashMap<String, List<ErrorDescriptor>>()
@@ -65,6 +104,60 @@ class KotlinToJSTranslator(
       }
       errorAnalyzer.errorsFrom(result.diagnostics.all(), errors)
       TranslationJSResult(errors = errors)
+    }
+  }
+
+  private fun webpackBundle(jsResult: TranslationJSResult, bundleType: BundleType): TranslationJSResult {
+    val jsCode = jsResult.jsCode
+    return if (jsCode != null) {
+      val tempDir = Files.createTempDirectory("kotlin-compiler-server").toFile()
+      try {
+        File(tempDir, "main.js").writeText(jsCode)
+        File(tempDir, "package.json").writeText(packageJson.asString())
+        val webpackConfig = if (bundleType == BundleType.PLAIN)
+          webpackConfigPlain
+        else
+          webpackConfigMinimized
+        File(tempDir, "webpack.config.js").writeText(
+          webpackConfig.asString()
+            .replace("###EXECUTOR_DIR###", librariesFile.js.absolutePath)
+            .replace("###TEMP_DIR###", tempDir.absolutePath)
+        )
+        runCommand("yarn install", tempDir)
+        runCommand("node_modules/.bin/webpack", tempDir)
+        val resultFile = File(tempDir, "main.bundle.js")
+        if (resultFile.exists()) {
+          jsResult.copy(jsCode = resultFile.readText())
+        } else {
+          jsResult.copy(exception = ExceptionDescriptor("Webpack processing failed"))
+        }
+      } catch (e: IOException) {
+        jsResult.copy(exception = e.toExceptionDescriptor())
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    } else {
+      jsResult.copy(exception = ExceptionDescriptor("Translated code is empty"))
+    }
+  }
+
+  private fun runCommand(
+    command: String,
+    workingDir: File = File("."),
+    timeoutAmount: Long = 60,
+    timeoutUnit: TimeUnit = TimeUnit.SECONDS
+  ): String {
+    return ProcessBuilder(command.split("\\s".toRegex()))
+      .directory(workingDir)
+      .redirectOutput(ProcessBuilder.Redirect.PIPE)
+      .redirectError(ProcessBuilder.Redirect.PIPE)
+      .start().apply { waitFor(timeoutAmount, timeoutUnit) }
+      .inputStream.bufferedReader().readText()
+  }
+
+  private fun Resource.asString(): String {
+    InputStreamReader(this.inputStream, Charsets.UTF_8).use { reader ->
+      return FileCopyUtils.copyToString(reader)
     }
   }
 }

--- a/src/main/kotlin/com/compiler/server/model/Project.kt
+++ b/src/main/kotlin/com/compiler/server/model/Project.kt
@@ -7,7 +7,8 @@ import com.fasterxml.jackson.annotation.JsonValue
 data class Project(
   val args: String = "",
   val files: List<ProjectFile> = listOf(),
-  val confType: ProjectType = ProjectType.JAVA
+  val confType: ProjectType = ProjectType.JAVA,
+  val bundleType: BundleType = BundleType.NONE
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -18,4 +19,10 @@ enum class ProjectType(@JsonValue val id: String) {
   JUNIT("junit"),
   CANVAS("canvas"),
   JS("js")
+}
+
+enum class BundleType(@JsonValue val id: String) {
+  NONE("none"),
+  PLAIN("plain"),
+  MINIMIZED("minimized")
 }

--- a/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
+++ b/src/main/kotlin/com/compiler/server/service/KotlinProjectExecutor.kt
@@ -31,7 +31,7 @@ class KotlinProjectExecutor(
 
   fun convertToJs(project: Project): TranslationJSResult {
     val files = getFilesFrom(project).map { it.kotlinFile }
-    return kotlinToJSTranslator.translate(files, project.args.split(" "))
+    return kotlinToJSTranslator.translate(files, project.args.split(" "), project.bundleType)
   }
 
   fun complete(project: Project, line: Int, character: Int): List<Completion> {

--- a/src/main/resources/package.json
+++ b/src/main/resources/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "devDependencies": {
+    "webpack": "4.41.2",
+    "webpack-cli": "3.3.9",
+    "uglifyjs-webpack-plugin": "2.2.0",
+    "css-loader": "3.3.2",
+    "style-loader": "1.0.1",
+    "file-loader": "5.0.2",
+    "url-loader": "3.0.0"
+  },
+  "dependencies": {},
+  "peerDependencies": {},
+  "optionalDependencies": {},
+  "bundledDependencies": [],
+  "name": "main",
+  "version": "1.0.0"
+}

--- a/src/main/resources/webpack.config.minimized.js
+++ b/src/main/resources/webpack.config.minimized.js
@@ -1,0 +1,55 @@
+var config = {
+  mode: 'production',
+  devtool: false,
+  resolve: {
+    modules: [
+      "###EXECUTOR_DIR###/META-INF/node_modules"
+    ]
+  },
+  plugins: [],
+  module: {
+    rules: [
+        {test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff'},
+        {test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream'},
+        {test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader'},
+        {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml'},
+        {test: /\.css$/, loader: "style-loader!css-loader" },
+        {test: /\.(jpe?g|png|gif)$/i, loader: 'file-loader', options: { esModule: false } }
+    ]
+  },
+  entry: [
+    "###TEMP_DIR###/main.js"
+  ],
+  output: {
+    path: "###TEMP_DIR###",
+    filename: "main.bundle.js"
+  }
+};
+
+;(function() {
+    const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+
+    config.optimization = {
+        minimizer: [
+             new UglifyJSPlugin({
+                uglifyOptions: {
+                    compress: {
+                        unused: false
+                    }
+                }
+             })
+        ]
+    }
+})();
+
+;(function() {
+    const webpack = require('webpack')
+
+    config.plugins.push(new webpack.ProvidePlugin({
+	$: "jquery",
+	jQuery: "jquery",
+	"window.jQuery": "jquery"
+    }));
+})();
+
+module.exports = config

--- a/src/main/resources/webpack.config.plain.js
+++ b/src/main/resources/webpack.config.plain.js
@@ -1,0 +1,42 @@
+var config = {
+  mode: 'production',
+  devtool: false,
+  resolve: {
+    modules: [
+      "###EXECUTOR_DIR###/META-INF/node_modules"
+    ]
+  },
+  optimization: {
+    minimize: false
+  },
+  plugins: [],
+  module: {
+    rules: [
+        {test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff'},
+        {test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream'},
+        {test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader'},
+        {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml'},
+        {test: /\.css$/, loader: "style-loader!css-loader" },
+        {test: /\.(jpe?g|png|gif)$/i, loader: 'file-loader', options: { esModule: false } }
+    ]
+  },
+  entry: [
+    "###TEMP_DIR###/main.js"
+  ],
+  output: {
+    path: "###TEMP_DIR###",
+    filename: "main.bundle.js"
+  }
+};
+
+;(function() {
+    const webpack = require('webpack')
+
+    config.plugins.push(new webpack.ProvidePlugin({
+	$: "jquery",
+	jQuery: "jquery",
+	"window.jQuery": "jquery"
+    }));
+})();
+
+module.exports = config


### PR DESCRIPTION
Support for bundling code with Webpack.

Requirements:
- working Node.js environment
- working Yarn installation

Gradle build creates additional directories in `META-INF` directory of JS executor. Requires working Yarn. If not available falls back to current behavior with a warning message.

New input project property `bundleType` with values:
- `none` (default, no bundling, current behavior)
- `plain` (Webpack processing without optimizations, fast but generates large output)
- `minimized` (Webpack processing with optimizations, generates minimized output but is quite slow)


