### PR TITLE
Use kotlin-test-junit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,7 @@ allprojects {
 }
 
 dependencies {
+    kotlinDependency("junit:junit:4.13.2")
     kotlinDependency("org.hamcrest:hamcrest:2.2")
     kotlinDependency("com.fasterxml.jackson.core:jackson-databind:$jacksonVersionKotlinDependencyJar")
     kotlinDependency("com.fasterxml.jackson.core:jackson-core:$jacksonVersionKotlinDependencyJar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,6 @@ allprojects {
 }
 
 dependencies {
-    kotlinDependency("junit:junit:4.13.2")
     kotlinDependency("org.hamcrest:hamcrest:2.2")
     kotlinDependency("com.fasterxml.jackson.core:jackson-databind:$jacksonVersionKotlinDependencyJar")
     kotlinDependency("com.fasterxml.jackson.core:jackson-core:$jacksonVersionKotlinDependencyJar")
@@ -84,6 +83,7 @@ dependencies {
     kotlinDependency("org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    kotlinDependency("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
 

--- a/src/test/kotlin/com/compiler/server/JUnitTestsRunnerTest.kt
+++ b/src/test/kotlin/com/compiler/server/JUnitTestsRunnerTest.kt
@@ -38,4 +38,21 @@ class JUnitTestsRunnerTest : BaseJUnitTest() {
       Assertions.assertTrue(it.expected == "OK")
     }
   }
+  
+  @Test
+  fun `supports kotlin test`() {
+    //language=kotlin
+    runKoanTest("""
+      import kotlin.test.Test
+      import kotlin.test.assertEquals
+      
+      class ToTest {
+        @Test
+        fun testing() {
+          assertEquals(42, 42)
+        }
+      }
+    """.trimIndent()
+    )
+  }
 }


### PR DESCRIPTION
Kotlin test junit contains the kotlin.test.Test typealias to org.junit.Test.
This change allows you to write a MPP test without explicit junit Test annotation:
```kotlin
import kotlin.test.*

class Testing
  @Test fun testing() {
    assertTrue(true) 
  }
}
```