### PR TITLE
Use jvmtoolchain to setup java source compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ val indexesJs: String by System.getProperties()
 
 group = "com.compiler.server"
 version = "$kotlinVersion-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_11
+kotlin.jvmToolchain(11)
 
 val kotlinDependency: Configuration by configurations.creating {
     isTransitive = false

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     kotlin("jvm")
 }
 
+kotlin.jvmToolchain(11)
+
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion")
     implementation("org.jetbrains.kotlin:common:222-$kotlinIdeVersion-IJ4167.29")

--- a/executors/build.gradle.kts
+++ b/executors/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   kotlin("jvm")
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
+kotlin.jvmToolchain(11)
 
 dependencies {
   implementation("junit:junit:4.13.2")

--- a/indexation/build.gradle.kts
+++ b/indexation/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
     application
 }
 
+kotlin.jvmToolchain(11)
+
 dependencies {
     implementation(project(":common", configuration = "default"))
     implementation("org.jetbrains.kotlin:kotlin-compiler-for-ide:$kotlinIdeVersion") {


### PR DESCRIPTION
This sets the correct JDK used by Gradle too. Otherwise, you need to change the JDK in IDEA project settings manually.

This would also allow you to remove the setup java steps in GitHub CI.