### PR TITLE
Revert "chore(deps): bump net.logstash.logback:logstash-logback-encoder from 7.3 to 7.4"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,7 +120,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.amazonaws.serverless:aws-serverless-java-container-springboot2:1.9.3")
     implementation("junit:junit:4.13.2")
-    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+    implementation("net.logstash.logback:logstash-logback-encoder:7.3")
     implementation("org.jetbrains.intellij.deps:trove4j:1.0.20221201")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")


### PR DESCRIPTION
Reverts JetBrains/kotlin-compiler-server#649