### PR TITLE
Fix 1.9.20 compatibilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
-val kotlinVersion: String by System.getProperties()
+val kotlinVersion = rootProject.properties["systemProp.kotlinVersion"]
 val kotlinIdeVersion: String by System.getProperties()
 val kotlinIdeVersionSuffix: String by System.getProperties()
 val policy: String by System.getProperties()
@@ -82,6 +82,7 @@ allprojects {
         maven("https://repo.spring.io/snapshot")
         maven("https://repo.spring.io/milestone")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://cache-redirector.jetbrains.com/jetbrains.bintray.com/intellij-third-party-dependencies")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
         maven("https://www.myget.org/F/rd-snapshots/maven/")
@@ -183,6 +184,7 @@ tasks.withType<KotlinCompile> {
     dependsOn(":indexation:run")
     buildPropertyFile()
 }
+println("Using Kotlin compiler $kotlinVersion")
 
 tasks.withType<BootJar> {
     requiresUnpack("**/kotlin-*.jar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ dependencies {
     kotlinDependency("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.2")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
-    kotlinWasmDependency("org.jetbrains.kotlin:kotlin-stdlib-wasm:$kotlinVersion")
+    kotlinWasmDependency("org.jetbrains.kotlin:kotlin-stdlib-wasm-js:$kotlinVersion")
 
     annotationProcessor("org.springframework:spring-context-indexer")
     implementation("com.google.code.gson:gson")
@@ -130,7 +130,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-script-runtime:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-compiler-for-ide:$kotlinIdeVersion"){
         isTransitive = false
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-systemProp.kotlinVersion=1.9.0
-systemProp.kotlinIdeVersion=1.9.0-356
-systemProp.kotlinIdeVersionSuffix=IJ8770.65
+systemProp.kotlinVersion=1.9.20-dev-8763
+systemProp.kotlinIdeVersion=1.9.20-dev-8884
+systemProp.kotlinIdeVersionSuffix=IJ8109.175
 systemProp.policy=executor.policy
 systemProp.indexes=indexes.json
 systemProp.indexesJs=indexesJs.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-systemProp.kotlinVersion=1.9.20-dev-8763
+systemProp.kotlinVersion=1.9.20-Beta-14
 systemProp.kotlinIdeVersion=1.9.20-dev-8884
 systemProp.kotlinIdeVersionSuffix=IJ8109.175
 systemProp.policy=executor.policy

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(":common")
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
     }

--- a/src/main/kotlin/com/compiler/server/compiler/components/KotlinToJSTranslator.kt
+++ b/src/main/kotlin/com/compiler/server/compiler/components/KotlinToJSTranslator.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.backend.wasm.wasmPhases
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.ir.backend.js.*
+import org.jetbrains.kotlin.ir.backend.js.dce.DceDumpNameCache
 import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.IrModuleToJsTransformer
 import org.jetbrains.kotlin.ir.backend.js.transformers.irToJs.TranslationMode
 import org.jetbrains.kotlin.ir.declarations.impl.IrFactoryImpl
@@ -168,7 +169,7 @@ class KotlinToJSTranslator(
       exportedDeclarations = setOf(FqName("main")),
       propertyLazyInitialization = true,
     )
-    eliminateDeadDeclarations(allModules, backendContext)
+    eliminateDeadDeclarations(allModules, backendContext, DceDumpNameCache())
 
     val res = compileWasm(
       allModules = allModules,


### PR DESCRIPTION
- Stdlib for wasm now has `wasm-js` suffix
- Indices for JS are based on IR stdlib