### PR TITLE
KTL-1313 Add support for explicit backing fields

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -42,6 +42,7 @@ class KotlinEnvironment(
       "-opt-in=kotlin.contracts.ExperimentalContracts",
       "-opt-in=kotlin.experimental.ExperimentalTypeInference",
       "-Xcontext-receivers",
+      "-XXLanguage:+ExplicitBackingFields"
     )
   }
 

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince170.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince170.kt
@@ -94,4 +94,28 @@ class KotlinFeatureSince170 : BaseExecutorTest() {
     contains = "second quarter"
     )
   }
+
+  @Test
+  fun `Experimental support for explicit backing fields`() {
+    run(
+      code = """
+        fun main() {
+          class Test {
+            val names: List<String>
+              field: MutableList<String> = mutableListOf<String>()
+  
+            fun doThing() {
+              names.add("Hello!")
+            }
+          }
+        
+          val test = Test()
+          test.doThing()
+
+          println(test.names)
+        }
+      """.trimIndent(),
+      contains = "[Hello!]"
+    )
+  }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1313/Add-support-for-explicit-backing-fields