### PR TITLE
fix JS example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -X POST \
       "files": [
         {
           "name": "File.kt",
-          "text": "fun main() {\n    println(args[0])\n }"
+          "text": "fun main(args: Array<String>) {\n    println(args[0])\n }"
         }
       ]
 }'


### PR DESCRIPTION
Currently, the example for "Translate Kotlin code to JavaScript code" sends the following Kotlin code to the compiler server:

```kotlin
fun main() {
    println(args[0])
}
```

This is invalid Kotlin code (atleast in 1.9.20) because `args` is an unresolved reference. The compiler server will return the following response:

```json
{
    "jsCode": null,
    "exception": null,
    "errors": {
        "File.kt": [
            {
                "interval": {
                    "start": {
                        "line": 1,
                        "ch": 12
                    },
                    "end": {
                        "line": 1,
                        "ch": 16
                    }
                },
                "message": "Unresolved reference: args",
                "severity": "ERROR",
                "className": "ERROR"
            }
        ]
    },
    "text": ""
}
```

I fixed it by changing the sent Kotlin code to:

```kotlin
fun main(args: Array<String>) {
    println(args[0])
}
```

The updated example will work as expected with the compiler server.