### PR TITLE
Upgrade to the latest kotlinx-datetime

### DIFF
--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -102,7 +102,7 @@ dependencies {
     kotlinDependency("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3")
     kotlinDependency("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-    kotlinDependency("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0-RC.2")
+    kotlinDependency("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-stdlib-js:$kotlinVersion")
     kotlinJsDependency("org.jetbrains.kotlin:kotlin-dom-api-compat:$kotlinVersion")
     kotlinWasmDependency("org.jetbrains.kotlin:kotlin-stdlib-wasm-js:$kotlinVersion")


### PR DESCRIPTION
By the way, is there a reason `kotlinx-coroutines-test` is an old version?