### PR TITLE
KTL-1636 Runnable Samples for uuid samples fail in Core API references

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -47,6 +47,7 @@ class KotlinEnvironment(
       "-opt-in=kotlin.ExperimentalUnsignedTypes",
       "-opt-in=kotlin.contracts.ExperimentalContracts",
       "-opt-in=kotlin.experimental.ExperimentalTypeInference",
+      "-opt-in=kotlin.uuid.ExperimentalUuidApi",
       "-Xcontext-receivers",
       "-Xreport-all-warnings",
       "-Xuse-fir-extended-checkers",

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince20.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince20.kt
@@ -1,0 +1,24 @@
+package com.compiler.server
+
+import com.compiler.server.base.BaseExecutorTest
+import org.junit.jupiter.api.Test
+
+class KotlinFeatureSince20 : BaseExecutorTest() {
+
+    @Test
+    fun `Support UUIDs`() {
+        run(
+            // language=kotlin
+            code = """
+                import kotlin.uuid.*
+
+                fun main(args: Array<String>) {
+                    val uuid = Uuid.parse("550E8400-e29b-41d4-A716-446655440000")
+                    println(uuid)
+                }
+            """.trimIndent(),
+            contains = "550e8400-e29b-41d4-a716-446655440000"
+        )
+    }
+}
+


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1636/Runnable-Samples-for-uuid-samples-fail-in-Core-API-references