### PR TITLE
KTL-1509 Opt-in kotlin.io.encoding.ExperimentalEncodingApi in playground

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -45,6 +45,7 @@ class KotlinEnvironment(
       "-opt-in=kotlin.ExperimentalUnsignedTypes",
       "-opt-in=kotlin.contracts.ExperimentalContracts",
       "-opt-in=kotlin.experimental.ExperimentalTypeInference",
+      "-opt-in=kotlin.io.encoding.ExperimentalEncodingApi",
       "-Xcontext-receivers",
       "-XXLanguage:+RangeUntilOperator"
     )

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince180.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince180.kt
@@ -64,5 +64,21 @@ class KotlinFeatureSince180 : BaseExecutorTest() {
             contains = "true"
         )
     }
+
+
+    @Test
+    fun `Support Experimental Encoding Api`() {
+        run(
+            // language=kotlin
+            code = """
+            import kotlin.io.encoding.Base64
+
+            fun main() {   
+               println(Base64.encode(byteArrayOf(1, 2, 3)))   
+            }
+            """.trimIndent(),
+            contains = "AQID"
+        )
+    }
 }
 


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTL-1509/Opt-in-kotlin.io.encoding.ExperimentalEncodingApi-in-playground