### PR TITLE
Fixed Configuration Cache problem for buildLambda task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,12 +130,14 @@ tasks.withType<BootJar> {
 }
 
 val buildLambda by tasks.creating(Zip::class) {
-    val lambdaWorkDirectoryPath = "/var/task/"
+    val propertyFile = propertyFile
+    val propertyFileContent = generateProperties("/var/task/")
+
     from(tasks.compileKotlin)
     from(tasks.processResources) {
         eachFile {
             if (name == propertyFile) {
-                file.writeText(generateProperties(lambdaWorkDirectoryPath))
+                file.writeText(propertyFileContent)
             }
         }
     }


### PR DESCRIPTION
The main reason of the problem was using the Project object in task action (https://docs.gradle.org/8.9/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution).