### PR TITLE
Opt-in ExperimentalAtomicApi

### DIFF
--- a/common/src/main/kotlin/component/KotlinEnvironment.kt
+++ b/common/src/main/kotlin/component/KotlinEnvironment.kt
@@ -50,6 +50,7 @@ class KotlinEnvironment(
       "-opt-in=kotlin.experimental.ExperimentalTypeInference",
       "-opt-in=kotlin.uuid.ExperimentalUuidApi",
       "-opt-in=kotlin.io.encoding.ExperimentalEncodingApi",
+      "-opt-in=kotlin.concurrent.atomics.ExperimentalAtomicApi",
       "-Xcontext-parameters",
       "-Xnested-type-aliases",
       "-Xreport-all-warnings",

--- a/src/test/kotlin/com/compiler/server/KotlinFeatureSince2120.kt
+++ b/src/test/kotlin/com/compiler/server/KotlinFeatureSince2120.kt
@@ -1,0 +1,22 @@
+package com.compiler.server
+
+import com.compiler.server.base.BaseExecutorTest
+import org.junit.jupiter.api.Test
+
+class KotlinFeatureSince2120 : BaseExecutorTest() {
+
+    @Test
+    fun `Support atomics`() {
+        run(
+            // language=kotlin
+            code = """
+                import kotlin.concurrent.atomics.*
+
+                fun main(args: Array<String>) {
+                    println(AtomicInt(42))
+                }
+            """.trimIndent(),
+            contains = "42"
+        )
+    }
+}


### PR DESCRIPTION
Opt-in `ExperimentalAtomicApi` annotation, which is required for common atomic types introduced in Kotlin 2.1.20.