### PR TITLE
KTL-2567: Added support for `kotlin-test-junit`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
     implementation(libs.intellij.trove4j)
     implementation(libs.kotlin.reflect)
     implementation(libs.bundles.kotlin.stdlib)
-    implementation(libs.kotlin.test)
     implementation(libs.kotlin.compiler)
     implementation(libs.kotlin.script.runtime)
     implementation(libs.kotlin.compiler.ide) {
@@ -59,6 +58,7 @@ dependencies {
     implementation(project(":executors", configuration = "default"))
     implementation(project(":common", configuration = "default"))
 
+    testImplementation(libs.kotlin.test)
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/dependencies/build.gradle.kts
+++ b/dependencies/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     // Kotlin libraries
     kotlinDependency(libs.bundles.kotlin.stdlib)
     kotlinDependency(libs.kotlin.test)
+    kotlinDependency(libs.kotlin.test.junit)
     kotlinDependency(libs.kotlinx.coroutines.core.jvm)
     kotlinDependency(libs.kotlinx.coroutines.test)
     kotlinDependency(libs.kotlinx.datetime)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ kotlin-stdlib-jdk8 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk
 kotlin-stdlib-js = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-js", version.ref = "kotlin" }
 kotlin-stdlib-wasm-js = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-wasm-js", version.ref = "kotlin" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 kotlin-compiler = { group = "org.jetbrains.kotlin", name = "kotlin-compiler", version.ref = "kotlin" }
 kotlin-script-runtime = { group = "org.jetbrains.kotlin", name = "kotlin-script-runtime", version.ref = "kotlin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/src/test/kotlin/com/compiler/server/JUnitTestsRunnerTest.kt
+++ b/src/test/kotlin/com/compiler/server/JUnitTestsRunnerTest.kt
@@ -4,85 +4,116 @@ import com.compiler.server.base.BaseJUnitTest
 import com.compiler.server.executor.ExecutorMessages
 import com.compiler.server.model.TestStatus
 import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
-import kotlin.test.assertContains
-import kotlin.test.assertNull
+import kotlin.test.*
 
 class JUnitTestsRunnerTest : BaseJUnitTest() {
 
-  @Test
-  fun `interrupt after a lot of text test`() {
-    val test = testRaw(
-      "fun start(): String {\n    repeat(100009){\n        print(\"alex\")\n    }\n    \n    return \"\"\n}",
-      "import org.junit.Assert\nimport org.junit.Test\n\nclass TestStart {\n    @Test fun testOk() {\n        Assert.assertEquals(\"OK\", start())\n    }\n}",
-      koansUtilsFile
-    )
-    val message = test?.text
-    Assertions.assertTrue(
-      message?.contains(ExecutorMessages.TOO_LONG_OUTPUT_MESSAGE) == true,
-      "Actual: $message, Excepted: ${ExecutorMessages.TOO_LONG_OUTPUT_MESSAGE} "
-    )
+    @Test
+    fun `interrupt after a lot of text test`() {
+        val test = testRaw(
+            "fun start(): String {\n    repeat(100009){\n        print(\"alex\")\n    }\n    \n    return \"\"\n}",
+            "import org.junit.Assert\nimport org.junit.Test\n\nclass TestStart {\n    @Test fun testOk() {\n        Assert.assertEquals(\"OK\", start())\n    }\n}",
+            koansUtilsFile
+        )
+        val message = test?.text
+        assertTrue(
+            message?.contains(ExecutorMessages.TOO_LONG_OUTPUT_MESSAGE) == true,
+            "Actual: $message, Excepted: ${ExecutorMessages.TOO_LONG_OUTPUT_MESSAGE} "
+        )
 
-  }
-
-  @Test
-  fun `base fail junit test`() {
-    @Language("kotlin")
-    val testCode = """
-      import org.junit.Assert
-      import org.junit.Test
-      
-      class TestStart {
-          @Test fun testOk() {
-              Assert.assertEquals("OK", start())
-          }
-      }
-    """.trimIndent()
-    val sourceCode = """fun start(): String = "OP""""
-    
-    val test = test(sourceCode, testCode, koansUtilsFile)
-    val fail = test.first()
-    Assertions.assertTrue(fail.status == TestStatus.FAIL)
-    Assertions.assertNotNull(fail.comparisonFailure, "comparisonFailure should not be a null")
-    fail.comparisonFailure?.let {
-      Assertions.assertTrue(it.actual == "OP")
-      Assertions.assertTrue(it.expected == "OK")
     }
-  }
-  
-  @Test
-  fun `no bytecode`() {
-    @Language("kotlin")
-    val testCode = """
-      import org.junit.Assert
-      import org.junit.Test
-      
-      class TestStart {
-          @Test fun testOk() {
-              Assert.assertEquals("OK", "OK")
+
+    @Test
+    fun `base fail junit test`() {
+        @Language("kotlin")
+        val testCode = """
+          import org.junit.Assert
+          import org.junit.Test
+          
+          class TestStart {
+              @Test fun testOk() {
+                  Assert.assertEquals("OK", start())
+              }
           }
-      }
-    """.trimIndent()
-    val testResults = testRaw(testCode, addByteCode = false)
-    assertNull(testResults!!.jvmByteCode, "Bytecode should not be generated")
-  }
-  
-  @Test
-  fun `with bytecode`() {
-    @Language("kotlin")
-    val testCode = """
-      import org.junit.Assert
-      import org.junit.Test
-      
-      class TestStart {
-          @Test fun testOk() {
-              Assert.assertEquals("OK", "OK")
+        """.trimIndent()
+        val sourceCode = """fun start(): String = "OP""""
+
+        val test = test(sourceCode, testCode, koansUtilsFile)
+        val fail = test.first()
+        assertTrue(fail.status == TestStatus.FAIL)
+        assertNotNull(fail.comparisonFailure, "comparisonFailure should not be a null")
+        fail.comparisonFailure.let {
+            assertTrue(it.actual == "OP")
+            assertTrue(it.expected == "OK")
+        }
+    }
+
+    @Test
+    fun `no bytecode`() {
+        @Language("kotlin")
+        val testCode = """
+          import org.junit.Assert
+          import org.junit.Test
+          
+          class TestStart {
+              @Test fun testOk() {
+                  Assert.assertEquals("OK", "OK")
+              }
           }
-      }
     """.trimIndent()
-    val testResults = testRaw(testCode, addByteCode = true)
-    val byteCode = testResults!!.jvmByteCode!!
-    assertContains(byteCode, "public final testOk()V")
-  }
+        val testResults = testRaw(testCode, addByteCode = false)
+        assertNull(testResults!!.jvmByteCode, "Bytecode should not be generated")
+    }
+
+    @Test
+    fun `with bytecode`() {
+        @Language("kotlin")
+        val testCode = """
+          import org.junit.Assert
+          import org.junit.Test
+          
+          class TestStart {
+              @Test fun testOk() {
+                  Assert.assertEquals("OK", "OK")
+              }
+          }
+        """.trimIndent()
+        val testResults = testRaw(testCode, addByteCode = true)
+        val byteCode = testResults!!.jvmByteCode!!
+        assertContains(byteCode, "public final testOk()V")
+    }
+
+    @Test
+    fun `junit without explicit import test`() {
+        @Language("kotlin")
+        val testCode =
+            $$"""
+            import kotlin.test.*
+
+            class SampleTest {
+                @Test
+                fun `test sum`() {
+                    val a = 1
+                    val b = 41
+                    assertEquals(42, sum(a, b), "Wrong result for sum($a, $b)")
+                }
+            
+                @Test
+                fun `test computation`() {
+                    assertTrue("Computation failed") {
+                        setup()
+                        compute()
+                    }
+                }
+            }
+            
+            fun sum(a: Int, b: Int) = a + b
+            fun setup() {}
+            fun compute() = true
+            """.trimIndent()
+        val testResults = test(testCode)
+        testResults.forEach { testResult ->
+            assertEquals(testResult.status, TestStatus.OK)
+        }
+    }
 }


### PR DESCRIPTION
We need support of `kotlin-test-junit` dependency to avoid explicit declaration of `import org.junit.Test`. Instead of this we can use `import kotlin.test.Test`