### PR TITLE
Redirected dependabot updates to the kotlin-community/dev.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
+    target-branch: "kotlin-community/dev"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -22,3 +23,4 @@ updates:
       - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
       - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
       - dependency-name: "org.jetbrains.kotlin.plugin.spring"
+      - dependency-name: "org.jetbrains.skiko:skiko-js-wasm-runtime"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ kotlinx-coroutines-test = "1.6.4"
 kotlinx-datetime = "0.7.1-0.6.x-compat"
 kotlinx-io = "0.8.0"
 kotlinx-serialization = "1.9.0"
-skiko = "0.9.27"
+skiko = "0.8.15"
 # don't forget to update jackson version in `executor.policy` file.
 jackson = "2.19.2"
 hamcrest = "3.0"


### PR DESCRIPTION
Also, skiko was reverted and added to the ignore list of dependabot because it should be updated manually.