### PR TITLE
feat: extend allowed compiler arguments for 2.4.0

### DIFF
--- a/src/main/kotlin/com/compiler/server/utils/CompilerArgumentsUtil.kt
+++ b/src/main/kotlin/com/compiler/server/utils/CompilerArgumentsUtil.kt
@@ -94,7 +94,10 @@ class CompilerArgumentsUtil(
         "Xallow-reified-type-in-catch",
         "Xallow-contracts-on-more-functions",
         "Xallow-condition-implies-returns-contracts",
-        "Xallow-holdsin-contract"
+        "Xallow-holdsin-contract",
+        "Xexplicit-context-arguments",
+        "Xcollection-literals",
+        "Xallow-returns-result-of",
     )
 
     internal val ALLOWED_JVM_ARGUMENTS = ALLOWED_COMMON_TOOL_ARGUMENTS + ALLOWED_COMMON_ARGUMENTS + setOf(


### PR DESCRIPTION

**Compiler argument support:**

- [`Xexplicit-context-arguments`](https://kotlinlang.org/docs/whatsnew24.html#explicit-context-arguments-for-context-parameters)
- [`Xcollection-literals`](https://kotlinlang.org/docs/whatsnew24.html#support-for-collection-literals)
- [`Xallow-returns-result-of`](https://kotlinlang.org/docs/whatsnew24.html#improved-unused-result-checks-for-higher-order-functions)