### PR TITLE
ci: notify Slack when a release branch build fails

### DIFF
--- a/.github/workflows/release-branch-failure-slack.yml
+++ b/.github/workflows/release-branch-failure-slack.yml
@@ -1,0 +1,74 @@
+name: Release branch build failure Slack notification
+
+# Fires after "Build compiler server with tests" finishes for a push to a
+# release branch. Release branches are named after the Kotlin version verbatim
+# (see docs/workflow.md "Release Flow"): 2.4.20, 2.4.20-RC, 2.4.20-Beta1.
+#
+# Kotlin versions are standard semver. The `branches` filter below is a GitHub
+# glob, which cannot express semver, so it only narrows the candidates; the
+# exact match is done in the job with the official semver regex.
+#
+# NOTE: workflow_run-triggered workflows only run from the default branch, so
+# this file must be merged into master to take effect.
+
+on:
+  workflow_run:
+    workflows: ["Build compiler server with tests"]
+    types:
+      - completed
+    branches:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  notify:
+    # `failure` covers a failed job; `timed_out` and `cancelled` are separate
+    # conclusions and are intentionally not treated as build failures here.
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify branch is a semver Kotlin version
+        id: version
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Official semver.org pattern, rewritten as POSIX ERE for bash `=~`
+          # (no non-capturing groups). Matches 2.4.20, 2.4.20-RC, 2.4.20-Beta1.
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+
+          if [[ ! "$BRANCH" =~ $semver ]]; then
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            echo "Branch '$BRANCH' is not a semver Kotlin version, skipping notification."
+            exit 0
+          fi
+
+          echo "matched=true" >> "$GITHUB_OUTPUT"
+          echo "version=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${BASH_REMATCH[5]}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: steps.version.outputs.matched == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILD_FAILURE_WEBHOOK_URL }}
+          VERSION: ${{ steps.version.outputs.version }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # A Slack incoming-webhook URL is itself the credential, so it is kept
+          # in a secret and never echoed.
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "::warning::SLACK_BUILD_FAILURE_WEBHOOK_URL is not configured, skipping Slack notification for $VERSION."
+            exit 0
+          fi
+
+          text=":x: Build failed on release branch \`$VERSION\` ($REPOSITORY@${HEAD_SHA:0:7})
+          $RUN_URL"
+
+          payload=$(jq -n --arg text "$text" '{ text: $text }')
+
+          curl --fail-with-body --silent --show-error \
+            --request POST "$SLACK_WEBHOOK_URL" \
+            --header "Content-Type: application/json" \
+            --data "$payload"


### PR DESCRIPTION
Counterpart to #997. Same `workflow_run` trigger on "Build compiler server with tests" and the same glob + semver gate on the branch name, but firing on a `failure` conclusion instead of `success`.

On a failed build of a release branch it posts to a Slack incoming webhook:

> :x: Build failed on release branch `2.4.20-RC` (JetBrains/kotlin-compiler-server@abc1234)
> <run url>